### PR TITLE
First pass at a new README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Service Delivery Handbook
+
+This is the GitHub repository for the [Service Delivery Handbook][handbook-url] for the _Taking Farmers to Markets_ program in the Australian Government [Department of Agriculture, Water and the Environment][dawe-url].
+
+We welcome contributions to the handbook, including pull requests. Read our [guide to editing the handbook][editing-url].
+
+## Licence
+
+All content is made available for reuse under the [CC BY 4.0 license][licence-url].
+
+[handbook-url]: https://handbook.agtrade.digital/
+[dawe-url]: https://www.awe.gov.au/
+[editing-url]: https://handbook.agtrade.digital/editing/
+[licence-url]: https://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
This adds a skeleton README file to the GitHub repository.

`README.md` is already listed in `.eleventyignore`, so it should be excluded from being built as part of the published handbook.